### PR TITLE
Remove capitalization of resource type

### DIFF
--- a/lib/todoist/service/base_service.rb
+++ b/lib/todoist/service/base_service.rb
@@ -49,7 +49,7 @@ module Todoist
 
       def all
         response = retrieve([resource_type_plural])
-        self.data = response[resource_type_plural.capitalize].map { |resource| collection_class.new(resource) }
+        self.data = response[resource_type_plural].map { |resource| collection_class.new(resource) }
       end
 
       def create(params, temp_id = nil)


### PR DESCRIPTION
The todoist api (`response`) returns the resource type in lowercase, if you capitalize it raises `NoMethodError`, because turns out to be nil. I think this is happen to be unnoticed because the all method doesn't not have a test.

I'm not sure, but I guess that's was something and old api version, maybe?